### PR TITLE
Revert "Update both Radicle Formulas to v3.0.0, add separate version file"

### DIFF
--- a/Formula/radicle-alpha-ipfs.rb
+++ b/Formula/radicle-alpha-ipfs.rb
@@ -1,13 +1,11 @@
-require "./version"
-
 class RadicleAlphaIpfs < Formula
-  @@version = RadicleVersion::VERSION
+  @@version = "2019.03.12-9ad916d"
   desc "Radicle IPFS backend"
   homepage "http://radicle.xyz"
   url "http://storage.googleapis.com/static.radicle.xyz/releases/radicle_#{@@version}_x86_64-darwin.tar.gz"
-  version "#{@@version}"
-  sha256 RadicleVersion::SHA256
-  head "https://github.com/radicle-dev/radicle"
+  version "0.1.0-#{@@version}"
+  sha256 "c92b7f8f35cc8c230372ba3c6b458ce3335302fdae2e1d241a4adbfee0240716"
+  head "https://github.com/oscoin/radicle"
 
   depends_on "ipfs"
 

--- a/Formula/radicle-alpha.rb
+++ b/Formula/radicle-alpha.rb
@@ -1,13 +1,11 @@
-require "./version"
-
 class RadicleAlpha < Formula
-  @@version = RadicleVersion::VERSION
+  @@version = "v0.0.3"
   desc "Peer-to-peer stack for code collaboration"
   homepage "https://radicle.xyz"
   url "http://storage.googleapis.com/static.radicle.xyz/releases/radicle_#{@@version}_x86_64-darwin.tar.gz"
   version "#{@@version}"
-  sha256 RadicleVersion::SHA256
-  head "https://github.com/radicle-dev/radicle"
+  sha256 "004cab2eaddfe3dcfcbaab59526545ab3b0639ff2fa21733c4bf42376e395951"
+  head "https://github.com/oscoin/radicle"
 
   depends_on "radicle-alpha-ipfs"
 

--- a/Formula/version.rb
+++ b/Formula/version.rb
@@ -1,4 +1,0 @@
-module RadicleVersion
-  VERSION = "v0.0.3"
-  SHA256 = "004cab2eaddfe3dcfcbaab59526545ab3b0639ff2fa21733c4bf42376e395951"
-end


### PR DESCRIPTION
welp... while this works fine when testing locally, once I push it to master and run `brew update`, homebrew things version.rb is a homebrew formula and gives an error when trying to load it.