### PR TITLE
Fix version file to work with require_relative

### DIFF
--- a/Formula/radicle-alpha-ipfs.rb
+++ b/Formula/radicle-alpha-ipfs.rb
@@ -1,12 +1,13 @@
+require_relative "version"
+
 class RadicleAlphaIpfs < Formula
-  @@version = "2019.03.12-9ad916d"
+  @@version = RadicleVersion::VERSION
   desc "Radicle IPFS backend"
   homepage "http://radicle.xyz"
   url "http://storage.googleapis.com/static.radicle.xyz/releases/radicle_#{@@version}_x86_64-darwin.tar.gz"
-  version "0.1.0-#{@@version}"
-  sha256 "c92b7f8f35cc8c230372ba3c6b458ce3335302fdae2e1d241a4adbfee0240716"
-  head "https://github.com/oscoin/radicle"
-
+  version "#{@@version}"
+  sha256 RadicleVersion::SHA256
+  head "https://github.com/radicle-dev/radicle"
   depends_on "ipfs"
 
   def install

--- a/Formula/radicle-alpha.rb
+++ b/Formula/radicle-alpha.rb
@@ -1,11 +1,13 @@
+require_relative "version"
+
 class RadicleAlpha < Formula
-  @@version = "v0.0.3"
+  @@version = RadicleVersion::VERSION
   desc "Peer-to-peer stack for code collaboration"
   homepage "https://radicle.xyz"
   url "http://storage.googleapis.com/static.radicle.xyz/releases/radicle_#{@@version}_x86_64-darwin.tar.gz"
   version "#{@@version}"
-  sha256 "004cab2eaddfe3dcfcbaab59526545ab3b0639ff2fa21733c4bf42376e395951"
-  head "https://github.com/oscoin/radicle"
+  sha256 RadicleVersion::SHA256
+  head "https://github.com/radicle-dev/radicle"
 
   depends_on "radicle-alpha-ipfs"
 

--- a/Formula/version.rb
+++ b/Formula/version.rb
@@ -1,0 +1,4 @@
+module RadicleVersion	
+  VERSION = "v0.0.3"	
+  SHA256 = "004cab2eaddfe3dcfcbaab59526545ab3b0639ff2fa21733c4bf42376e395951"	
+end


### PR DESCRIPTION
This should do it. Previously, it worked because I was testing from the same directory as the files, so did not have an error when running via `require` instead of `require_relative`.